### PR TITLE
Fixes for errors when server is restarting or disabled

### DIFF
--- a/client/extension.ts
+++ b/client/extension.ts
@@ -379,7 +379,7 @@ async function initLanguageServerClient(context: ExtensionContext, outputChannel
                 if (selected === "Disabled" ){
                     // Stop the client if the selected profile is "Disabled"
                     // We already got the configurations
-                    global.LSCLIENT.stop();
+                    await stopClient();
                 }
             }),
             client.onNotification("$Odoo/invalid_python_path", async(params) => {
@@ -473,6 +473,11 @@ async function initializeSubscriptions(context: ExtensionContext): Promise<void>
 
                 if (!global.IS_PYTHON_EXTENSION_READY){
                     onDidChangePythonInterpreterEvent.fire(null);
+                }
+                const selected = workspace.getConfiguration().get("Odoo.selectedProfile") as string;
+                if (selected === "Disabled") {
+                    await setStatusConfig(context);
+                    return;
                 }
                 let client = global.LSCLIENT;
                 if (!client) {
@@ -719,11 +724,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
         deleteOldFiles(context);
         global.LSCLIENT.info('Starting the extension.');
         await setStatusConfig(context);
-        global.LSCLIENT.start();
+        await global.LSCLIENT.start();
     }
     catch (error) {
         displayCrashMessage(context, error, global.SERVER_PID, 'odoo.activate');
-        global.LSCLIENT.error(error);
+        global.LSCLIENT?.error(error);
     }
 }
 

--- a/client/extension.ts
+++ b/client/extension.ts
@@ -381,6 +381,7 @@ async function initLanguageServerClient(context: ExtensionContext, outputChannel
                     // We already got the configurations
                     await stopClient();
                 }
+                await setStatusConfig(context);
             }),
             client.onNotification("$Odoo/invalid_python_path", async(params) => {
                 await window.showInformationMessage(
@@ -391,11 +392,9 @@ async function initLanguageServerClient(context: ExtensionContext, outputChannel
                 await displayCrashMessage(context, params["crashInfo"], params["pid"], params["recentMessages"]);
             }),
             client.onNotification("$Odoo/restartNeeded", async () => {
-                if (global.LSCLIENT) {
-                    global.LSCLIENT.restart();
-                    global.LOADING_STATUS = "READY";
-                    await setStatusConfig(context);
-                }
+                await restartClient();
+                global.LOADING_STATUS = "READY";
+                await setStatusConfig(context);
             })
         );
         global.PATH_VARIABLES = {"userHome" : homedir().replaceAll("\\","/")};
@@ -549,11 +548,9 @@ async function initializeSubscriptions(context: ExtensionContext): Promise<void>
             ),
         commands.registerCommand(
             "odoo.restartServer", async () => {
-                if (global.LSCLIENT) {
-                    global.LSCLIENT.restart();
-                    global.LOADING_STATUS = "READY";
-                    await setStatusConfig(context);
-                }
+                await restartClient();
+                global.LOADING_STATUS = "READY";
+                await setStatusConfig(context);
         }),
         commands.registerCommand("odoo.showServerConfig", async () => {
             showConfigPreview("__all__");
@@ -742,13 +739,32 @@ async function waitForClientStop() {
 
 async function stopClient() {
     if (global.LSCLIENT && !global.CLIENT_IS_STOPPING) {
-        global.LSCLIENT.info("Stopping LS Client.");
+        global.LSCLIENT.info("[stopClient] Stopping LS Client.");
         global.LOADING_STATUS = "READY";
         global.CLIENT_IS_STOPPING = true;
         await global.LSCLIENT.stop(15000);
         global.CLIENT_IS_STOPPING = false;
         clientStopped.fire(null);
-        global.LSCLIENT.info("LS Client stopped.");
+        global.LSCLIENT.info("[stopClient] LS Client stopped.");
+    } else {
+        global.LSCLIENT?.info(`[stopClient] Skipped — LSCLIENT=${!!global.LSCLIENT}, CLIENT_IS_STOPPING=${global.CLIENT_IS_STOPPING}`);
+    }
+}
+
+async function restartClient() {
+    if (!global.LSCLIENT) return;
+    if (global.CLIENT_IS_STOPPING) {
+        global.LSCLIENT.info("[restartClient] Client is stopping, waiting...");
+        await waitForClientStop();
+    }
+    if (global.LSCLIENT.needsStart()) {
+        global.LSCLIENT.info("[restartClient] Client needs start — starting.");
+        await global.LSCLIENT.start();
+        global.LSCLIENT.info("[restartClient] Client started.");
+    } else {
+        global.LSCLIENT.info("[restartClient] Restarting LS Client.");
+        await global.LSCLIENT.restart();
+        global.LSCLIENT.info("[restartClient] Client restarted.");
     }
 }
 
@@ -864,8 +880,12 @@ async function showConfigProfileQuickPick(context: ExtensionContext) {
         showConfigPreview("__all__");
       } else {
         const ok = await changeSelectedConfig(context, selection.label);
-        if (ok && global.LSCLIENT) {
-            global.LSCLIENT.restart();
+        if (ok) {
+            if (selection.label === "Disabled") {
+                await stopClient();
+            } else {
+                await restartClient();
+            }
             global.LOADING_STATUS = "READY";
             await setStatusConfig(context);
         }


### PR DESCRIPTION
We get multiple crash reports with just `{}` perhaps it is a crash in the client when the Disabled profile is chosen.


When the "Disabled" profile is selected,
the extension should not attempt to start the language server,
which can lead to crashes.
This commit adds a check for the "Disabled" profile before initializing the language server client,
ensuring that the extension remains stable even when the user has chosen to disable it.

It also checks on change of configuration if the
"Disabled" profile is selected and sets the status
accordingly without trying to start the language server.

And that was the reason for the crash reports,
i.e. disabled profile and then change config